### PR TITLE
Fix/pet categories

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,7 +22,7 @@ import {
   postPet,
   patchPet,
   deletePet,
-  getBreedsByCategory,
+  getBreeds,
 } from './pets';
 
 import {
@@ -56,7 +56,7 @@ export {
   postPet,
   patchPet,
   deletePet,
-  getBreedsByCategory,
+  getBreeds,
   getMedications,
   getMedicationsByPet,
   postMedication,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,7 +23,6 @@ import {
   patchPet,
   deletePet,
   getBreedsByCategory,
-  getPetCategories,
 } from './pets';
 
 import {
@@ -58,7 +57,6 @@ export {
   patchPet,
   deletePet,
   getBreedsByCategory,
-  getPetCategories,
   getMedications,
   getMedicationsByPet,
   postMedication,

--- a/src/api/pets/index.ts
+++ b/src/api/pets/index.ts
@@ -22,6 +22,10 @@ export function deletePet(petId: number) {
   return destroy(`/pets/${petId}/`);
 }
 
-export function getBreedsByCategory(categoryId: number) {
-  return get<Breed[]>(`/pets/breeds/?categoryId=${categoryId}`);
+export function getBreeds(categoryId?: number) {
+  const url = '/pets/breeds/';
+  if (categoryId) {
+    url.concat(`?categoryId=${categoryId}`);
+  }
+  return get<Breed[]>(url);
 }

--- a/src/api/pets/index.ts
+++ b/src/api/pets/index.ts
@@ -1,6 +1,6 @@
 import { get, post, patch, destroy } from '../config';
 
-import type { Breed, Pet, PetCategory, PetForm } from './types';
+import type { Breed, Pet, PetForm } from './types';
 
 export function getPets() {
   return get<Pet[]>('/pets/');
@@ -24,8 +24,4 @@ export function deletePet(petId: number) {
 
 export function getBreedsByCategory(categoryId: number) {
   return get<Breed[]>(`/pets/breeds/?categoryId=${categoryId}`);
-}
-
-export function getPetCategories() {
-  return get<PetCategory[]>('/pets/categories/');
 }

--- a/src/components/AddPetModal/AddPetForm.tsx
+++ b/src/components/AddPetModal/AddPetForm.tsx
@@ -1,28 +1,20 @@
-// General Imports
 import React, { useEffect, useState, useContext } from 'react';
-
-// Component Imports
 import { Container, Row, Col } from 'react-bootstrap';
-
-// Hook Imports
 import { useNavigate } from 'react-router-dom';
 
-// Context Imports
 import PetsContext from '../../context/PetsContext';
-
-// Util Imports
-import { getBreedsByCategory } from '../../api';
+import { getBreeds } from '../../api';
 import AuthContext from '../../context/AuthContext';
 import { Breed, Gender, PetCategory, PetForm } from '../../api/pets/types';
 
 const petCategories: PetCategory[] = [
   {
     id: 1,
-    category: 'Cat'
+    category: 'Dog'
   },
   {
     id: 2,
-    category: 'Dog'
+    category: 'Cat'
   }
 ];
 
@@ -40,10 +32,8 @@ const AddPetForm = () => {
   const { user } = useContext(AuthContext);
   
   useEffect(() => {
-    if (categoryId) {
-      getBreedsByCategory(categoryId).then((res) => setBreedOptions(res.data));
-    }
-  }, [categoryId]);
+    getBreeds().then((res) => setBreedOptions(res.data));
+  }, []);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -95,7 +85,7 @@ const AddPetForm = () => {
               <Col>
                 <select onChange={(e) => setBreedId(parseInt(e.target.value))}>
                   <option value={undefined}>---</option>
-                  {breedOptions.map((b) => {
+                  {breedOptions.filter(b => b.category.id === categoryId).map((b) => {
                     return (
                       <option key={b.id} value={b.id}>
                         {b.name}

--- a/src/components/AddPetModal/AddPetForm.tsx
+++ b/src/components/AddPetModal/AddPetForm.tsx
@@ -11,14 +11,23 @@ import { useNavigate } from 'react-router-dom';
 import PetsContext from '../../context/PetsContext';
 
 // Util Imports
-import { getBreedsByCategory, getPetCategories } from '../../api';
+import { getBreedsByCategory } from '../../api';
 import AuthContext from '../../context/AuthContext';
 import { Breed, Gender, PetCategory, PetForm } from '../../api/pets/types';
 
-const AddPetForm = () => {
-  const [categoryOptions, setCategoryOptions] = useState<PetCategory[]>([]);
-  const [breedOptions, setBreedOptions] = useState<Breed[]>([]);
+const petCategories: PetCategory[] = [
+  {
+    id: 1,
+    category: 'Cat'
+  },
+  {
+    id: 2,
+    category: 'Dog'
+  }
+];
 
+const AddPetForm = () => {
+  const [breedOptions, setBreedOptions] = useState<Breed[]>([]);
   const [name, setName] = useState<string>();
   const [categoryId, setCategoryId] = useState<number>();
   const [breedId, setBreedId] = useState<number>();
@@ -29,13 +38,7 @@ const AddPetForm = () => {
   const navigate = useNavigate();
   const { addPet } = useContext(PetsContext);
   const { user } = useContext(AuthContext);
-
-  useEffect(() => {
-    getPetCategories()
-      .then((res) => setCategoryOptions(res.data))
-      .catch((err) => console.log(err));
-  }, []);
-
+  
   useEffect(() => {
     if (categoryId) {
       getBreedsByCategory(categoryId).then((res) => setBreedOptions(res.data));
@@ -76,7 +79,7 @@ const AddPetForm = () => {
             <Col>
               <select onChange={(e) => setCategoryId(parseInt(e.target.value))}>
                 <option value={undefined}>---</option>
-                {categoryOptions.map((c) => {
+                {petCategories.map((c) => {
                   return (
                     <option key={c.id} value={c.id}>
                       {c.category}

--- a/src/components/BioWidget/BioInfoEdit.tsx
+++ b/src/components/BioWidget/BioInfoEdit.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Row, Col } from 'react-bootstrap';
 
 // Util Imports
-import { getBreedsByCategory, patchPet } from '../../api';
+import { getBreeds, patchPet } from '../../api';
 
 import type { Breed, Gender, Pet } from '../../api/pets/types';
 
@@ -21,7 +21,7 @@ const BioInfoEdit: React.FC<Props> = ({ pet, setEditMode, setNeedsUpdate }) => {
   const [birthday, setBirthday] = useState(pet.birthday);
 
   useEffect(() => {
-    getBreedsByCategory(pet.category.id)
+    getBreeds(pet.category.id)
       .then((res) => setBreedOptions(res.data))
       .catch((err) => console.log(err));
   }, []);


### PR DESCRIPTION
API calls to backend for pet category, breed options are now fixed, so that users can successfully add Dogs or Cats to their profile.

Some slight functionality changes: 
- all breeds are fetched on Add Pet form load and filtered in memory based on selected category
- `categoryId` param in `getBreedsByCategory` is now optional, since the query param is optional at the endpoint